### PR TITLE
Multi sign

### DIFF
--- a/examples/cars/commands/mint.go
+++ b/examples/cars/commands/mint.go
@@ -66,7 +66,7 @@ func MintRequest(demoDir, dealerID, carRegistration string, lg *logger.SugarLogg
 		return "", errors.Wrap(err, "error during transaction commit")
 	}
 
-	txEnv, err := dataTx.TxEnvelope()
+	txEnv, err := dataTx.CommittedTxEnvelope()
 	if err != nil {
 		return "", errors.New("error getting transaction envelope")
 	}
@@ -158,7 +158,7 @@ func MintApprove(demoDir, dmvID, mintReqRecordKey string, lg *logger.SugarLogger
 		return "", errors.Wrap(err, "error during transaction commit")
 	}
 
-	txEnv, err := dataTx.TxEnvelope()
+	txEnv, err := dataTx.CommittedTxEnvelope()
 	if err != nil {
 		return "", errors.New("error getting transaction envelope")
 	}

--- a/examples/cars/commands/transafer.go
+++ b/examples/cars/commands/transafer.go
@@ -74,7 +74,7 @@ func TransferTo(demoDir, ownerID, buyerID, carRegistration string, lg *logger.Su
 		return "", errors.Wrap(err, "error during transaction commit")
 	}
 
-	txEnv, err := dataTx.TxEnvelope()
+	txEnv, err := dataTx.CommittedTxEnvelope()
 	if err != nil {
 		return "", errors.New("error getting transaction envelope")
 	}
@@ -163,7 +163,7 @@ func TransferReceive(demoDir, buyerID, carRegistration, transferToRecordKey stri
 		return "", errors.Wrap(err, "error during transaction commit")
 	}
 
-	txEnv, err := dataTx.TxEnvelope()
+	txEnv, err := dataTx.CommittedTxEnvelope()
 	if err != nil {
 		return "", errors.New("error getting transaction envelope")
 	}
@@ -259,7 +259,7 @@ func Transfer(demoDir, dmvID, transferToRecordKey, transferRcvRecordKey string, 
 		return "", errors.Wrap(err, "error during transaction commit")
 	}
 
-	txEnv, err := dataTx.TxEnvelope()
+	txEnv, err := dataTx.CommittedTxEnvelope()
 	if err != nil {
 		return "", errors.New("error getting transaction envelope")
 	}

--- a/pkg/bcdb/db.go
+++ b/pkg/bcdb/db.go
@@ -27,6 +27,7 @@ type BCDB interface {
 type DBSession interface {
 	UsersTx() (UsersTxContext, error)
 	DataTx() (DataTxContext, error)
+	LoadDataTx(*types.DataTxEnvelope) (LoadedDataTxContext, error)
 	DBsTx() (DBsTxContext, error)
 	ConfigTx() (ConfigTxContext, error)
 	Provenance() (Provenance, error)
@@ -46,8 +47,8 @@ type TxContext interface {
 	// Abort cancel submission and abandon all changes
 	// within given transaction context
 	Abort() error
-	// TxEnvelope returns transaction envelope, can be called only after Commit(), otherwise will return nil
-	TxEnvelope() (proto.Message, error)
+	// CommittedTxEnvelope returns transaction envelope, can be called only after Commit(), otherwise will return nil
+	CommittedTxEnvelope() (proto.Message, error)
 }
 
 type Ledger interface {

--- a/pkg/bcdb/loaded_data_tx_context.go
+++ b/pkg/bcdb/loaded_data_tx_context.go
@@ -1,0 +1,160 @@
+// Copyright IBM Corp. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package bcdb
+
+import (
+	"github.com/IBM-Blockchain/bcdb-server/pkg/constants"
+	"github.com/IBM-Blockchain/bcdb-server/pkg/cryptoservice"
+	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
+	"github.com/golang/protobuf/proto"
+)
+
+type dbWrites struct {
+}
+
+// LoadedDataTxContext provides methods to realize multi-sign transaction.
+// When a user receives a pre-compiled transaction envelope, the loaded
+// transaction context can be used to load the pre-compiled envelope,
+// inspect the operations performed by the transaction, and either
+// co-sign the transaction to get the transaction envelope (maybe to
+// pass it on to other users) or issue commit (which would internally
+// co-sign the transaction).
+type LoadedDataTxContext interface {
+	// Embed general abstraction
+	TxContext
+	// MustSignUsers returns all the users in the MustSignUsers set of the
+	// loaded multi-sign data tx. All those users must sign the transaction
+	// for it to be valid. Note that, in addition, the signature of some
+	// additional users may be needed, depending on the write ACLs of the
+	// keys in the write-set."
+	MustSignUsers() []string
+	// SignedUsers returns all users who have signed the transaction envelope
+	SignedUsers() []string
+	// VerifySignatures verifies the existing signature on the loaded data transactions
+	VerifySignatures() error
+	// Reads return all read operations performed by the load data transaction on
+	// different databases
+	Reads() map[string][]*types.DataRead
+	// Writes return all write operations performed by the load data transaction on
+	// different databases
+	Writes() map[string][]*types.DataWrite
+	// Deletes return all delete operations performed by the load data transaction on
+	// different databases
+	Deletes() map[string][]*types.DataDelete
+	// CoSignTxEnvelopeAndCloseTx adds the signature of the transaction's user to
+	// the envelope, closes the transaction, and return the co-signed
+	// transaction envelope
+	CoSignTxEnvelopeAndCloseTx() (proto.Message, error)
+}
+
+type loadedDataTxContext struct {
+	*commonTxContext
+	txEnv *types.DataTxEnvelope
+}
+
+func (d *loadedDataTxContext) Commit(sync bool) (string, *types.TxReceipt, error) {
+	return d.commit(d, constants.PostDataTx, sync)
+}
+
+func (d *loadedDataTxContext) Abort() error {
+	return d.abort(d)
+}
+
+// CoSignTxEnvelopeAndCloseTx adds the signature of the transaction's user to
+// the envelope, closes the transaction, and return the co-signed
+// transaction envelope
+func (d *loadedDataTxContext) CoSignTxEnvelopeAndCloseTx() (proto.Message, error) {
+	d.logger.Debugf("compose transaction enveloped with txID = %s", d.txID)
+
+	var err error
+	d.txEnvelope, err = d.composeEnvelope(d.txID)
+	if err != nil {
+		d.logger.Errorf("failed to compose transaction envelope, due to %s", err)
+		return nil, err
+	}
+
+	d.txSpent = true
+	d.cleanCtx()
+	return d.txEnvelope, nil
+}
+
+// MustSignUsers returns all users of the loaded multi-sign data tx
+func (d *loadedDataTxContext) MustSignUsers() []string {
+	return d.txEnv.Payload.MustSignUserIds
+}
+
+// SignedUsers returns all users who have signed the transaction envelope
+func (d *loadedDataTxContext) SignedUsers() []string {
+	var users []string
+
+	for user := range d.txEnv.Signatures {
+		users = append(users, user)
+	}
+
+	return users
+}
+
+// Reads return all read operations performed by the load data transaction on
+// different databases
+func (d *loadedDataTxContext) Reads() map[string][]*types.DataRead {
+	reads := make(map[string][]*types.DataRead)
+	for _, dbOps := range d.txEnv.Payload.DbOperations {
+		var dr []*types.DataRead
+		for _, r := range dbOps.DataReads {
+			dr = append(dr, r)
+		}
+		reads[dbOps.DbName] = dr
+	}
+
+	return reads
+}
+
+// Writes return all write operations performed by the load data transaction on
+// different databases
+func (d *loadedDataTxContext) Writes() map[string][]*types.DataWrite {
+	writes := make(map[string][]*types.DataWrite)
+	for _, dbOps := range d.txEnv.Payload.DbOperations {
+		var dw []*types.DataWrite
+		for _, w := range dbOps.DataWrites {
+			dw = append(dw, w)
+		}
+		writes[dbOps.DbName] = dw
+	}
+
+	return writes
+}
+
+// Deletes return all delete operations performed by the load data transaction on
+// different databases
+func (d *loadedDataTxContext) Deletes() map[string][]*types.DataDelete {
+	deletes := make(map[string][]*types.DataDelete)
+	for _, dbOps := range d.txEnv.Payload.DbOperations {
+		var dd []*types.DataDelete
+		for _, d := range dbOps.DataDeletes {
+			dd = append(dd, d)
+		}
+		deletes[dbOps.DbName] = dd
+	}
+
+	return deletes
+}
+
+func (d *loadedDataTxContext) VerifySignatures() error {
+	// TODO issue 174
+	return nil
+}
+
+func (d *loadedDataTxContext) composeEnvelope(_ string) (proto.Message, error) {
+	signature, err := cryptoservice.SignTx(d.signer, d.txEnv.Payload)
+	if err != nil {
+		return nil, err
+	}
+
+	d.txEnv.Signatures[d.userID] = signature
+
+	return d.txEnv, nil
+}
+
+func (d *loadedDataTxContext) cleanCtx() {
+	d.txEnv = nil
+}

--- a/pkg/bcdb/loaded_data_tx_context_test.go
+++ b/pkg/bcdb/loaded_data_tx_context_test.go
@@ -1,0 +1,280 @@
+// Copyright IBM Corp. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package bcdb
+
+import (
+	"io/ioutil"
+	"path"
+	"testing"
+
+	"github.com/IBM-Blockchain/bcdb-server/pkg/server/testutils"
+	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadedDataContext_CommitConstructedMultiSign(t *testing.T) {
+	clientCertTemDir := testutils.GenerateTestClientCrypto(t, []string{"admin", "alice", "bob", "server"})
+	testServer, _, _, err := SetupTestServer(t, clientCertTemDir)
+	defer testServer.Stop()
+	require.NoError(t, err)
+	StartTestServer(t, testServer)
+
+	bcdb, adminSession := connectAndOpenAdminSession(t, testServer, clientCertTemDir)
+	createDB(t, "db1", adminSession)
+	createDB(t, "db2", adminSession)
+	aliceCert, err := ioutil.ReadFile(path.Join(clientCertTemDir, "alice.pem"))
+	require.NoError(t, err)
+	dbPerm := map[string]types.Privilege_Access{
+		"db1": 1,
+		"db2": 1,
+	}
+	addUser(t, "alice", adminSession, aliceCert, dbPerm)
+
+	bobCert, err := ioutil.ReadFile(path.Join(clientCertTemDir, "bob.pem"))
+	require.NoError(t, err)
+	addUser(t, "bob", adminSession, bobCert, dbPerm)
+
+	userSession := openUserSession(t, bcdb, "alice", clientCertTemDir)
+	putKeySync(t, "db1", "key3", "value3", "alice", userSession)
+	putKeySync(t, "db1", "key4", "value4", "alice", userSession)
+	putKeySync(t, "db2", "key3", "value3", "alice", userSession)
+	putKeySync(t, "db2", "key4", "value4", "alice", userSession)
+
+	tx, err := userSession.DataTx()
+	require.NoError(t, err)
+	require.NotNil(t, tx)
+	for _, dbName := range []string{"db1", "db2"} {
+		for _, keyPostfix := range []string{"3", "4"} {
+			val, meta, err := tx.Get(dbName, "key"+keyPostfix)
+			require.NoError(t, err)
+			require.NotNil(t, meta)
+			require.Equal(t, []byte("value"+keyPostfix), val)
+		}
+	}
+	require.NoError(t, tx.Abort())
+
+	tx, err = userSession.DataTx()
+	require.NoError(t, err)
+	require.NotNil(t, tx)
+
+	require.NoError(t, tx.AssertRead("db1", "key1", nil))
+	require.NoError(t, tx.AssertRead("db1", "key2", nil))
+	require.NoError(t, tx.AssertRead("db2", "key1", nil))
+	require.NoError(t, tx.AssertRead("db2", "key2", nil))
+	require.NoError(t, tx.Put("db1", "key1", []byte("value1"), nil))
+	require.NoError(t, tx.Put("db1", "key2", []byte("value2"), nil))
+	require.NoError(t, tx.Put("db2", "key1", []byte("value1"), nil))
+	require.NoError(t, tx.Put("db2", "key2", []byte("value2"), nil))
+	require.NoError(t, tx.Delete("db1", "key3"))
+	require.NoError(t, tx.Delete("db1", "key4"))
+	require.NoError(t, tx.Delete("db2", "key3"))
+	require.NoError(t, tx.Delete("db2", "key4"))
+
+	tx.AddMustSignUser("bob")
+
+	txEnv, err := tx.SignConstructedTxEnvelopeAndCloseTx()
+	require.NoError(t, err)
+	require.NotNil(t, txEnv)
+	require.Len(t, txEnv.(*types.DataTxEnvelope).Signatures, 1)
+
+	t.Run("commit constructed envelope after signing", func(t *testing.T) {
+		txEnv := proto.Clone(txEnv)
+		userSession = openUserSession(t, bcdb, "bob", clientCertTemDir)
+
+		dataTxEnv := txEnv.(*types.DataTxEnvelope)
+		loadedTx, err := userSession.LoadDataTx(dataTxEnv)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"alice", "bob"}, loadedTx.MustSignUsers())
+		require.ElementsMatch(t, []string{"alice"}, loadedTx.SignedUsers())
+
+		txID, receipt, err := loadedTx.Commit(true)
+		require.NoError(t, err)
+		require.NotNil(t, receipt)
+		require.Equal(t, dataTxEnv.Payload.TxId, txID)
+
+		tx, err = userSession.DataTx()
+		require.NoError(t, err)
+
+		for _, dbName := range []string{"db1", "db2"} {
+			for _, keyPostfix := range []string{"3", "4"} {
+				val, meta, err := tx.Get(dbName, "key"+keyPostfix)
+				require.NoError(t, err)
+				require.Nil(t, val)
+				require.Nil(t, meta)
+			}
+		}
+		for _, dbName := range []string{"db1", "db2"} {
+			for _, keyPostfix := range []string{"1", "2"} {
+				val, meta, err := tx.Get(dbName, "key"+keyPostfix)
+				require.NoError(t, err)
+				require.NotNil(t, meta)
+				require.Equal(t, []byte("value"+keyPostfix), val)
+			}
+		}
+
+		require.NoError(t, tx.Abort())
+	})
+
+	t.Run("fetch constructed envelope after signing", func(t *testing.T) {
+		txEnv := proto.Clone(txEnv)
+		userSession = openUserSession(t, bcdb, "bob", clientCertTemDir)
+
+		dataTxEnv := txEnv.(*types.DataTxEnvelope)
+		loadedTx, err := userSession.LoadDataTx(dataTxEnv)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"alice", "bob"}, loadedTx.MustSignUsers())
+		require.ElementsMatch(t, []string{"alice"}, loadedTx.SignedUsers())
+
+		reads := loadedTx.Reads()
+		expectedReads := map[string][]*types.DataRead{
+			"db1": {
+				{
+					Key:     "key1",
+					Version: nil,
+				},
+				{
+					Key:     "key2",
+					Version: nil,
+				},
+			},
+			"db2": {
+				{
+					Key:     "key1",
+					Version: nil,
+				},
+				{
+					Key:     "key2",
+					Version: nil,
+				},
+			},
+		}
+		require.Len(t, reads, len(expectedReads))
+		for dbName := range expectedReads {
+			require.ElementsMatch(t, expectedReads[dbName], reads[dbName])
+		}
+
+		writes := loadedTx.Writes()
+		expectedWrites := map[string][]*types.DataWrite{
+			"db1": {
+				{
+					Key:   "key1",
+					Value: []byte("value1"),
+				},
+				{
+					Key:   "key2",
+					Value: []byte("value2"),
+				},
+			},
+			"db2": {
+				{
+					Key:   "key1",
+					Value: []byte("value1"),
+				},
+				{
+					Key:   "key2",
+					Value: []byte("value2"),
+				},
+			},
+		}
+		require.Len(t, writes, len(expectedWrites))
+		for dbName := range expectedWrites {
+			require.ElementsMatch(t, expectedWrites[dbName], writes[dbName])
+		}
+
+		deletes := loadedTx.Deletes()
+		expectedDeletes := map[string][]*types.DataDelete{
+			"db1": {
+				{
+					Key: "key3",
+				},
+				{
+					Key: "key4",
+				},
+			},
+			"db2": {
+				{
+					Key: "key3",
+				},
+				{
+					Key: "key4",
+				},
+			},
+		}
+		require.Len(t, deletes, len(expectedDeletes))
+		for dbName := range expectedDeletes {
+			require.ElementsMatch(t, expectedDeletes[dbName], deletes[dbName])
+		}
+
+		newTxEnv, err := loadedTx.CoSignTxEnvelopeAndCloseTx()
+		require.NoError(t, err)
+		require.NotNil(t, newTxEnv)
+		newDataTxEnv := newTxEnv.(*types.DataTxEnvelope)
+		require.Equal(t, dataTxEnv.Payload, newDataTxEnv.Payload)
+		require.Len(t, newDataTxEnv.Signatures, 2)
+		bobSign, ok := newDataTxEnv.Signatures["bob"]
+		require.True(t, ok)
+		require.NotNil(t, bobSign)
+	})
+}
+
+func TestLoadedDataContext_ErrorCase(t *testing.T) {
+	clientCertTemDir := testutils.GenerateTestClientCrypto(t, []string{"admin", "server"})
+	testServer, _, _, err := SetupTestServer(t, clientCertTemDir)
+	defer testServer.Stop()
+	require.NoError(t, err)
+	StartTestServer(t, testServer)
+
+	bcdb, _ := connectAndOpenAdminSession(t, testServer, clientCertTemDir)
+
+	userSession := openUserSession(t, bcdb, "admin", clientCertTemDir)
+
+	loadedTxCtx, err := userSession.LoadDataTx(nil)
+	require.EqualError(t, err, "transaction envelope is nil")
+	require.Nil(t, loadedTxCtx)
+
+	loadedTxCtx, err = userSession.LoadDataTx(
+		&types.DataTxEnvelope{
+			Payload: nil,
+		},
+	)
+	require.EqualError(t, err, "payload in the transaction envelope is nil")
+	require.Nil(t, loadedTxCtx)
+
+	loadedTxCtx, err = userSession.LoadDataTx(
+		&types.DataTxEnvelope{
+			Payload: &types.DataTx{
+				MustSignUserIds: []string{"alice"},
+			},
+		},
+	)
+	require.EqualError(t, err, "transaction envelope does not have a signature")
+	require.Nil(t, loadedTxCtx)
+
+	loadedTxCtx, err = userSession.LoadDataTx(
+		&types.DataTxEnvelope{
+			Payload: &types.DataTx{
+				MustSignUserIds: []string{"alice"},
+			},
+			Signatures: map[string][]byte{
+				"alice": []byte("sign"),
+			},
+		},
+	)
+	require.EqualError(t, err, "transaction ID in the transaction envelope is empty")
+	require.Nil(t, loadedTxCtx)
+
+	loadedTxCtx, err = userSession.LoadDataTx(
+		&types.DataTxEnvelope{
+			Payload: &types.DataTx{
+				MustSignUserIds: []string{},
+				TxId:            "tx1",
+			},
+			Signatures: map[string][]byte{
+				"alice": []byte("sign"),
+			},
+		},
+	)
+	require.EqualError(t, err, "no user ID in the transaction envelope")
+	require.Nil(t, loadedTxCtx)
+}

--- a/pkg/bcdb/tx_context_test.go
+++ b/pkg/bcdb/tx_context_test.go
@@ -492,7 +492,7 @@ func TestTxCommit(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			env, err := tt.txCtx.TxEnvelope()
+			env, err := tt.txCtx.CommittedTxEnvelope()
 			require.Error(t, err)
 			require.Contains(t, "can't access tx envelope, transaction not finalized", err.Error())
 			require.Nil(t, env)
@@ -503,7 +503,7 @@ func TestTxCommit(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			env, err = tt.txCtx.TxEnvelope()
+			env, err = tt.txCtx.CommittedTxEnvelope()
 			require.NoError(t, err)
 			require.NotNil(t, env)
 			if tt.syncCommit {
@@ -597,7 +597,7 @@ func TestTxQuery(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			env, err := tt.txCtx.TxEnvelope()
+			env, err := tt.txCtx.CommittedTxEnvelope()
 			require.Error(t, err)
 			require.Contains(t, "can't access tx envelope, transaction not finalized", err.Error())
 			require.Nil(t, env)

--- a/pkg/bcdb/util_test.go
+++ b/pkg/bcdb/util_test.go
@@ -212,7 +212,7 @@ func assertTxFinality(t *testing.T, txFinality TxFinality, tx TxContext, userSes
 		switch tx.(type) {
 		case ConfigTxContext:
 			// TODO remove once support for non data tx provenance added
-			e, _ := tx.TxEnvelope()
+			e, _ := tx.CommittedTxEnvelope()
 			env := e.(*types.ConfigTxEnvelope)
 			newConfig := env.GetPayload().GetNewConfig()
 			require.Eventually(t, func() bool {
@@ -231,7 +231,7 @@ func assertTxFinality(t *testing.T, txFinality TxFinality, tx TxContext, userSes
 			waitForTx(t, txID, userSession)
 		case DBsTxContext:
 			// TODO remove once support for non data tx provenance added
-			e, _ := tx.TxEnvelope()
+			e, _ := tx.CommittedTxEnvelope()
 			env := e.(*types.DBAdministrationTxEnvelope)
 			createdDBs := env.GetPayload().GetCreateDbs()
 			deletedDBs := env.GetPayload().GetDeleteDbs()
@@ -265,7 +265,7 @@ func assertTxFinality(t *testing.T, txFinality TxFinality, tx TxContext, userSes
 
 		case UsersTxContext:
 			// TODO remove once support for non data tx provenance added
-			e, _ := tx.TxEnvelope()
+			e, _ := tx.CommittedTxEnvelope()
 			env := e.(*types.UserAdministrationTxEnvelope)
 			deleteUsers := env.GetPayload().GetUserDeletes()
 			updateUsers := env.GetPayload().GetUserWrites()


### PR DESCRIPTION
This commit adds a necessary interface to data transaction context such that the user can collect multiple signatures for an executed transaction. 